### PR TITLE
feat(users): add minimal user model and endpoints

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -25,7 +25,7 @@ activities = {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
         "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
+    "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
     },
     "Programming Class": {
         "description": "Learn programming fundamentals and build software projects",
@@ -77,6 +77,41 @@ activities = {
     }
 }
 
+# In-memory users store. Keys are user IDs (simple incremental ints as strings)
+users = {}
+_next_user_id = 1
+
+
+def _create_user_if_missing(email: str, name: str | None = None, role: str | None = None, bio: str | None = None):
+    """Ensure a user exists for the given email. If not, create a minimal user and return its id."""
+    global _next_user_id
+    # search for existing user by email
+    for uid, u in users.items():
+        if u.get("email") == email:
+            return uid
+
+    uid = str(_next_user_id)
+    users[uid] = {"id": uid, "email": email, "name": name or email.split("@")[0], "role": role or "student", "bio": bio or ""}
+    _next_user_id += 1
+    return uid
+
+
+# Migrate existing activity participants (emails) into user ids on startup
+def _migrate_participants_to_user_ids():
+    for activity in activities.values():
+        migrated = []
+        for p in activity.get("participants", []):
+            # if participant already looks like a user id (digits), keep
+            if isinstance(p, str) and p.isdigit() and p in users:
+                migrated.append(p)
+            else:
+                migrated.append(_create_user_if_missing(p))
+        activity["participants"] = migrated
+
+
+# Run migration on import
+_migrate_participants_to_user_ids()
+
 
 @app.get("/")
 def root():
@@ -88,8 +123,32 @@ def get_activities():
     return activities
 
 
+@app.post("/users")
+def create_user(email: str, name: str | None = None, role: str | None = None, bio: str | None = None):
+    """Create a new user (minimal). Returns the created user's id and data."""
+    # simple validation
+    if not email or "@" not in email:
+        raise HTTPException(status_code=400, detail="Invalid email")
+
+    # Prevent duplicates
+    for u in users.values():
+        if u.get("email") == email:
+            raise HTTPException(status_code=400, detail="User with this email already exists")
+
+    uid = _create_user_if_missing(email=email, name=name, role=role, bio=bio)
+    return users[uid]
+
+
+@app.get("/users/{user_id}")
+def get_user(user_id: str):
+    u = users.get(user_id)
+    if not u:
+        raise HTTPException(status_code=404, detail="User not found")
+    return u
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str, email: str, user_id: str | None = None):
     """Sign up a student for an activity"""
     # Validate activity exists
     if activity_name not in activities:
@@ -98,20 +157,24 @@ def signup_for_activity(activity_name: str, email: str):
     # Get the specific activity
     activity = activities[activity_name]
 
+    # Determine the user id for this signup (create user if needed)
+    if user_id is None:
+        user_id = _create_user_if_missing(email)
+
     # Validate student is not already signed up
-    if email in activity["participants"]:
+    if user_id in activity["participants"]:
         raise HTTPException(
             status_code=400,
             detail="Student is already signed up"
         )
 
-    # Add student
-    activity["participants"].append(email)
-    return {"message": f"Signed up {email} for {activity_name}"}
+    # Add student by user id
+    activity["participants"].append(user_id)
+    return {"message": f"Signed up {email} (user id: {user_id}) for {activity_name}", "user_id": user_id}
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(activity_name: str, email: str = None, user_id: str = None):
     """Unregister a student from an activity"""
     # Validate activity exists
     if activity_name not in activities:
@@ -120,13 +183,21 @@ def unregister_from_activity(activity_name: str, email: str):
     # Get the specific activity
     activity = activities[activity_name]
 
+    # Resolve user id if email provided
+    if user_id is None and email is not None:
+        # find user id by email
+        for uid, u in users.items():
+            if u.get("email") == email:
+                user_id = uid
+                break
+
     # Validate student is signed up
-    if email not in activity["participants"]:
+    if user_id is None or user_id not in activity["participants"]:
         raise HTTPException(
             status_code=400,
             detail="Student is not signed up for this activity"
         )
 
     # Remove student
-    activity["participants"].remove(email)
-    return {"message": f"Unregistered {email} from {activity_name}"}
+    activity["participants"].remove(user_id)
+    return {"message": f"Unregistered user id {user_id} from {activity_name}"}


### PR DESCRIPTION
This PR introduces a minimal in-memory users store and endpoints to create and fetch users. It also migrates existing activity participants (emails) into generated user IDs and updates signup/unregister endpoints to operate on user IDs.\n\nChanges:\n- Add `users` in-memory store and helper `_create_user_if_missing`\n- Migrate participants on import to user IDs\n- `POST /users` to create a user\n- `GET /users/{user_id}` to fetch a user\n- `POST /activities/{activity_name}/signup` updated to accept/create user ids\n- `DELETE /activities/{activity_name}/unregister` updated to accept email or user_id\n\nThis is a first step towards full user accounts and will be followed by persistence and authentication work.