### PR TITLE
docs: fix exercise content and install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ Remember, it's self-paced so feel free to take a break! ☕️
 
 ---
 
-&copy; 2025 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)
+&copy; 2025 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://opensource.org/licenses/MIT)
 

--- a/src/README.md
+++ b/src/README.md
@@ -9,10 +9,10 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 ## Getting Started
 
-1. Install the dependencies:
+1. Install the dependencies (recommended: use the included requirements.txt):
 
    ```
-   pip install fastapi uvicorn
+   pip install -r requirements.txt
    ```
 
 2. Run the application:


### PR DESCRIPTION
Fixes and clarifies exercise content: correct MIT license link in root README and recommend installing dependencies via requirements.txt in src README.